### PR TITLE
Make project consumable via Git URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
 
 # Gatsby files
 .cache/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "build": "node ./node_modules/.bin/tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
Add build scripts and include `dist` directory in the repository.

* **package.json**
  - Add `prepublishOnly` script to run the build script before publishing.
  - Add `prepare` script to run the build script before packaging.

* **.gitignore**
  - Remove the `dist` directory from the `.gitignore` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/salestracker/lumos-ts/pull/1?shareId=64143cb7-f7b2-45a8-bb29-7ff512be3a09).