### PR TITLE
Fix types declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git+https://github.com/salestracker/lumos-ts.git.git"
   },
   "main": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Update the `package.json` file to correctly point to the declaration file.

* Change the `"types"` field from `"dist/types/index.d.ts"` to `"dist/index.d.ts"` in the `package.json` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/salestracker/lumos-ts?shareId=XXXX-XXXX-XXXX-XXXX).